### PR TITLE
Dzil compliant

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,0 +1,20 @@
+name = vrtrack_crawl
+author = Andrew Page
+license = GPL_3
+copyright_holder = Wellcome Trust Sanger Institute
+copyright_year = 2013
+main_module = modules/VRTrackCrawl/Assemblies.pm
+
+[MetaResources]
+homepage = http://www.sanger.ac.uk/
+repository.web = https://github.com/sanger-pathogens/vrtrack_crawl
+repository.url = https://github.com/sanger-pathogens/vrtrack_crawl.git
+repository.type = git
+
+
+[@Basic]
+[AutoPrereqs]
+[PruneCruft]
+[ExtraTests]
+[AutoVersion]
+[PodWeaver]


### PR DESCRIPTION
Simply needed a dist.ini like the one added to build successfully with Dist::Zilla.
No further changes needed for this.